### PR TITLE
ci: init gitlint check for SAP-compliant commits

### DIFF
--- a/.config/gitlint/rules/on-behalf-of-marker.py
+++ b/.config/gitlint/rules/on-behalf-of-marker.py
@@ -1,0 +1,36 @@
+from gitlint.rules import LineRule, RuleViolation, CommitMessageTitle, CommitRule
+
+class BodyContainsOnBehalfOfSAPMarker(CommitRule):
+  """Enforce that each commit coming from an SAP contractor contains an
+  "On-behalf-of SAP user@sap.com" marker.
+  """
+
+  # A rule MUST have a human friendly name
+  name = "body-requires-on-behalf-of-sap"
+
+  # A rule MUST have a *unique* id
+  # We recommend starting with UC (for User-defined Commit-rule).
+  id = "UC-sap"
+
+  # Lower-case list of contractors
+  contractors = [
+    "@cyberus-technology.de"
+  ]
+
+  # Marker followed by " name.surname@sap.com"
+  marker = "On-behalf-of: SAP"
+
+  def validate(self, commit):
+    if "@sap.com" in commit.author_email.lower():
+      return
+
+    # Allow third-party open-source contributions
+    if not any(contractor in commit.author_email.lower() for contractor in self.contractors):
+      return
+
+    for line in commit.message.body:
+      if line.startswith(self.marker) and "@sap.com" in line.lower():
+        return
+
+    msg = f"Body does not contain a '{self.marker} user@sap.com' line"
+    return [RuleViolation(self.id, msg, line_nr=1)]

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,23 @@
+name: Commit Lint
+on: [ pull_request ]
+jobs:
+  gitlint:
+    name: Check commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade gitlint
+      - name: Lint git commit messages
+        run: |
+          gitlint --commits origin/$GITHUB_BASE_REF..

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /buildDir # default meson build dir by CLion IDE
 /memtouch
 /result*
+
+__pycache__

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,20 @@
+[general]
+extra-path=.config/gitlint/rules
+regex-style-search=true
+ignore=body-is-missing
+
+[ignore-by-author-name]
+regex=dependabot
+ignore=all
+
+# default 72
+[title-max-length]
+line-length=72
+
+# default 80
+[body-max-line-length]
+line-length=72
+
+# Empty bodies are fine
+[body-min-length]
+min-length=0

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,8 @@
       devShells.x86_64-linux.default = pkgs.mkShell {
         inputsFrom = [ self.packages.x86_64-linux.memtouch ];
         packages = with pkgs; [
+          # Check last commit locally: `gitlint --debug`
+          gitlint
           nixfmt-rfc-style
         ];
       };


### PR DESCRIPTION
We at Cyberus commit with our @cyberus-technology.de emails. To be compliant with SAP, we use gitlint to check if we include the mandatory "On-behalf-of: SAP" line in each commit.

To develop and play around with gitlint, you may use
- `gitlint --commits HEAD~1..HEAD`
- `gitlint --debug`

On-behalf-of: SAP philipp.schuster@sap.com