### PR TITLE
Use AVX-512 streaming instructions to increase write throughput

### DIFF
--- a/consts.hpp
+++ b/consts.hpp
@@ -1,0 +1,10 @@
+#ifndef CONSTS_HPP
+#define CONSTS_HPP
+
+#include <cstdint>
+
+inline static constexpr uint64_t PAGE_SIZE(4096);
+inline static constexpr int      PATTERN(0xff);
+inline static constexpr int      DEFAULT_STAT_IVAL(1000);
+
+#endif

--- a/memtouch.cpp
+++ b/memtouch.cpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <chrono>
+#include <consts.hpp>
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <functional>
@@ -12,14 +15,15 @@
 #include <assert.h>
 #include <signal.h>
 #include <sys/mman.h>
+#include <xmmintrin.h>
+
+#if defined(__x86_64__)
+#include <write_pages_avx512.hpp>
+#endif
 
 #ifndef PROJECT_VERSION
 #define PROJECT_VERSION "0.0.0"
 #endif
-
-static constexpr uint64_t PAGE_SIZE(4096);
-static constexpr int      PATTERN(0xff);
-static constexpr int      DEFAULT_STAT_IVAL(1000);
 
 using namespace std;
 
@@ -41,13 +45,16 @@ class WorkerThread {
                  bool     run_once_,
                  unsigned mem_size_mib_,
                  unsigned rw_ratio_,
-                 uint64_t page_log_ival_)
+                 uint64_t page_log_ival_,
+                 bool     no_avx_)
         : id(id_),
           run_once(run_once_),
           mem_size_mib(mem_size_mib_),
           rw_ratio(rw_ratio_),
           page_log_ival(page_log_ival_),
-          stats() {}
+          stats() {
+        avx512_streaming = __builtin_cpu_supports("avx512f") && (!no_avx_);
+    }
 
     bool pre_run() {
         if (not allocate_memory()) {
@@ -55,6 +62,10 @@ class WorkerThread {
             return false;
         }
 
+        if (avx512_streaming) {
+            auto addr_base = reinterpret_cast<uint64_t>(mem_base);
+            assert((addr_base % 64) == 0);
+        }
         return true;
     }
 
@@ -68,7 +79,7 @@ class WorkerThread {
             if (terminate) {
                 break;
             }
-            write_page(page);
+            write_pages(page, 1);
         }
 
         if (run_once) {
@@ -133,12 +144,8 @@ class WorkerThread {
 
             pages_read += pages_to_read_eff;
 
-            auto time_write_ns = measure_time_ns([&]() {
-                for (uint64_t n{0}; n < pages_to_write_eff; ++n) {
-                    auto page = n + pages_read + pages_written;
-                    write_page(page);
-                }
-            });
+            auto time_write_ns = measure_time_ns(
+                [&]() { write_pages(pages_read + pages_written, pages_to_write_eff); });
 
             pages_written += pages_to_write_eff;
 
@@ -162,6 +169,17 @@ class WorkerThread {
 
     void write_page(uint64_t page) {
         memset(static_cast<char*>(mem_base) + page * PAGE_SIZE, PATTERN, PAGE_SIZE);
+    }
+
+    void write_pages(uint64_t page_start, uint64_t num_pages) {
+        if (avx512_streaming) {
+            return streaming_write_pages_avx512(mem_base, page_start, num_pages);
+        }
+
+        for (uint64_t n{0}; n < num_pages; ++n) {
+            auto page = page_start + n;
+            write_page(page);
+        }
     }
 
     void read_page(uint64_t page, void* buffer) {
@@ -193,6 +211,7 @@ class WorkerThread {
     unsigned mem_size_mib;
     unsigned rw_ratio;
     uint64_t page_log_ival;
+    bool     avx512_streaming;
 
     bool terminate{false};
 
@@ -330,6 +349,11 @@ void setup_argparse(argparse::ArgumentParser& program, int argc, char** argv) {
         .default_value(false)
         .implicit_value(true);
 
+    program.add_argument("--no_avx")
+        .help("disable 512-bit non-temporal writes even if they are available")
+        .default_value(false)
+        .implicit_value(true);
+
     try {
         program.parse_args(argc, argv);
     } catch (const std::exception& err) {
@@ -349,6 +373,7 @@ int main(int argc, char** argv) {
     auto num_threads = program.get<unsigned>("--num_threads");
     auto rw_ratio    = program.get<unsigned>("--rw_ratio");
     auto once        = program.get<bool>("--once");
+    auto no_avx      = program.get<bool>("--no_avx");
 
     std::string stats_file;
     unsigned    stats_ival;
@@ -401,7 +426,7 @@ int main(int argc, char** argv) {
     thread_storage.reserve(num_threads + 1 /* statistics thread */);
 
     for (unsigned num_thread = 0; num_thread < num_threads; num_thread++) {
-        worker_storage.emplace_back(num_thread, once, thread_mem, rw_ratio, page_log_ival);
+        worker_storage.emplace_back(num_thread, once, thread_mem, rw_ratio, page_log_ival, no_avx);
         if (not worker_storage.back().pre_run()) {
             worker_storage.clear();
             return 1;

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ cpp_flags = [
   '-Wswitch-enum',
   '-Wvla',
   '-Wuseless-cast',
+  '-ffat-lto-objects', # Does not compile without this: Get error plugin required to handle lto
   '-fcf-protection=return',
   '-fstack-protector-strong', # Stack smashing protection
   '-fstack-clash-protection', # Prevent stack clash attacks
@@ -43,6 +44,14 @@ cpp_flags = [
   '-DPROJECT_VERSION="' + meson.project_version() + '"'
 ]
 
+# One of our dependencies needs the avx512f flag, but we don't want everything to
+# be compiled with this flag
+write_pages_avx512_lib_flags = cpp_flags
+avx512_foundations = '-mavx512f'
+if target_machine.cpu_family() == 'x86_64'
+  write_pages_avx512_lib_flags += avx512_foundations
+endif
+
 # Linker flags
 linker_flags = [
   '-Wl,-z,nodlopen', # Prevent dlopen()
@@ -53,6 +62,26 @@ linker_flags = [
   '-Wl,--no-copy-dt-needed-entries',
 ]
 
+# Shared constants
+consts_lib = static_library(
+  'consts',
+  sources: ['consts.hpp'],
+  cpp_args: cpp_flags,
+  link_args: linker_flags
+)
+
+consts_lib_dep = declare_dependency(link_with: consts_lib)
+
+# AVX512 write_pages implementation
+write_pages_avx512_lib = static_library(
+  'write_pages_avx512',
+  sources : ['write_pages_avx512.cpp', 'write_pages_avx512.hpp'],
+  cpp_args: write_pages_avx512_lib_flags,
+  link_args: linker_flags,
+  dependencies: [consts_lib_dep]
+)
+
+write_pages_avx512_lib_dep = declare_dependency(link_with: write_pages_avx512_lib)
 # Add include directory as a system directory, so that lints/warnings do not
 # run on them.
 include_dir = include_directories('include', is_system: true)
@@ -62,6 +91,7 @@ executable(
   'memtouch.cpp',
   include_directories : include_dir,
   install : true,
+  dependencies: [consts_lib_dep, write_pages_avx512_lib_dep],
   cpp_args : cpp_flags,
   link_args : linker_flags
 )

--- a/write_pages_avx512.cpp
+++ b/write_pages_avx512.cpp
@@ -1,0 +1,34 @@
+#include <cstdint>
+#include <cstdio>
+#include <write_pages_avx512.hpp>
+#include "consts.hpp"
+
+// Dependents are responsible for checking that `avx512f` is available at runtime
+#if defined(__x86_64__)
+#include <immintrin.h>
+void streaming_write_pages_avx512(void* mem_base, uint64_t page_start, uint64_t num_pages) {
+    // Write 4 * 64 bytes per iteration until we are done
+    // TODO: Compile time assert that PAGE_SIZE is indeed divisible by 64 * 4
+    auto  num_iterations = num_pages * (PAGE_SIZE / (64 * 4));
+    auto  pattern        = _mm512_set1_epi8(static_cast<int8_t>(PATTERN));
+    char* mem_addr       = ((char*)mem_base) + (page_start * PAGE_SIZE);
+    for (uint64_t n{0}; n < num_iterations; ++n) {
+        _mm512_stream_si512(reinterpret_cast<__m512i*>(mem_addr), pattern);
+        _mm512_stream_si512(reinterpret_cast<__m512i*>(mem_addr + 64), pattern);
+        _mm512_stream_si512(reinterpret_cast<__m512i*>(mem_addr + (2 * 64)), pattern);
+        _mm512_stream_si512(reinterpret_cast<__m512i*>(mem_addr + (3 * 64)), pattern);
+        mem_addr += (4 * 64);
+    }
+    // Non-temporal stores are weakly ordered hence we apply a fence to ensure that
+    // our stores are ordered before any subsequent (in program order) loads and stores.
+    _mm_sfence();
+}
+#else
+void streaming_write_pages_avx512(void* mem_base, uint64_t page_start, uint64_t num_pages) {
+    (void)mem_base;
+    (void)page_start;
+    (void)num_pages;
+    printf("this function should not be called\n");
+    std::abort();
+}
+#endif

--- a/write_pages_avx512.hpp
+++ b/write_pages_avx512.hpp
@@ -1,0 +1,8 @@
+#ifndef WRITE_PAGES_AVX512_HPP
+#define WRITE_PAGES_AVX512_HPP
+
+#include <cstdint>
+
+void streaming_write_pages_avx512(void* mem_base, uint64_t page_start, uint64_t num_pages);
+
+#endif


### PR DESCRIPTION
Non-temporal stores are known to help in the case of bulk write workloads. This PR thus replaces the write_page loops with a function issuing `VMOVNTDQ` instructions in a loop (storing 4 `zmm` registers to memory with a non-temporal hint per iteration) whenever `avx512f` is available.

## Benchmarks

TL;DR: write_mibps increases by a factor between roughly 1.7 and 4x depending on the parameters, but read_mibps suffers by roughly 15-30% on Intel Sapphire Rapids + Granite Rapids and is roughly halved in the 50% read case on AMD Turin (Zen 5).

All benchmarks are performed in a Cloud hypervisor guest with direct Kernel boot.

### RW_RATIO = 100

#### Intel Sapphire Rapids

**Before this change:** 
```
bash/root# memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
...
2026-04-28T12:56:41.602+0000 read_mibps:0.00 write_mibps:15288.66
```

**With this change:**
```
 memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:35:45.080+0000 read_mibps:0.00 write_mibps:25405.31
```

#### Intel Granite Rapids

**Before this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:46:35.919+0000 read_mibps:0.00 write_mibps:48910.51
```

**After this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:53:06.093+0000 read_mibps:0.00 write_mibps:130104.02
```

#### AMD Turin (Zen 5)

**Before this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
... 
2026-04-29T10:31:51.814+0000 read_mibps:0.00 write_mibps:26124.03
```

**After this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 100 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T10:37:53.614+0000 read_mibps:0.00 write_mibps:43241.38
```

### RW_RATIO=50

#### Sapphire Rapids

**Before this change:**
```
bash/root# memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-28T12:57:53.182+0000 read_mibps:26912.37 write_mibps:14626.11
...
2026-04-28T12:57:55.722+0000 read_mibps:23788.17 write_mibps:13883.67
...
2026-04-28T12:58:00.395+0000 read_mibps:23918.18 write_mibps:13850.72
```

**After this change:**
```
bash/root# memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:36:45.700+0000 read_mibps:19492.00 write_mibps:38896.96
...
2026-04-29T09:36:46.007+0000 read_mibps:18174.73 write_mibps:50314.11
...
2026-04-29T09:36:47.128+0000 read_mibps:16523.04 write_mibps:62170.18
...
2026-04-29T09:36:51.501+0000 read_mibps:17868.51 write_mibps:37468.30
```

We now have much less consistent numbers, but writes are always much higher and reads always a bit lower.

#### Granite Rapids

**Before this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:47:30.464+0000 read_mibps:89452.20 write_mibps:54063.75
...
2026-04-29T09:47:31.273+0000 read_mibps:89169.32 write_mibps:53755.64
...
2026-04-29T09:47:35.014+0000 read_mibps:93118.45 write_mibps:53443.48
```

**After this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T09:58:05.398+0000 read_mibps:79570.14 write_mibps:203479.06
...
2026-04-29T09:58:07.522+0000 read_mibps:77014.87 write_mibps:205501.08
...
...2026-04-29T09:58:11.973+0000 read_mibps:77247.63 write_mibps:207418.56
```

We still get roughly 4x more write_mibps and the read_mibps is penalized a bit less than on the Sapphire Rapids.

#### AMD Turin (Zen 5)

**Before this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T10:32:55.493+0000 read_mibps:50831.60 write_mibps:28478.09
...
2026-04-29T10:32:57.234+0000 read_mibps:52024.53 write_mibps:29265.94
...
2026-04-29T10:33:00.001+0000 read_mibps:49901.25 write_mibps:28015.01
```

**After this change:**
```
memtouch --num_threads 8 --thread_mem 512 --rw_ratio 50 --stat_ival 100 --stat_file /dev/console
...
2026-04-29T10:38:50.926+0000 read_mibps:28641.04 write_mibps:96322.76
...
2026-04-29T10:38:52.863+0000 read_mibps:27180.42 write_mibps:112658.40
...
2026-04-29T10:38:55.923+0000 read_mibps:26728.97 write_mibps:118604.88
```

We here see that write_mibps is increased by around 4x, but  read_mibps is almost halved though.

## Implementation details

This is my first time writing C++ and using Meson. There is thus probably a lot of room for improvements!

### C++ Code

I branch on a pre-computed bool in the `write_pages` function and execute the fast path when `avx512f` is available on x86_64 targets. Normally one would perhaps rather use dynamic dispatch through a function pointer here, but I am not sure how one would write that in C++. In this particular case I also expect the performance penalty of including effectively dead code at the beginning of the function call to be rather negligible in comparison to the time spent in the hot write loop.

### Meson
In order to compile the avx512 code one needs to supply the `avx512f` flag to the compiler, but we don't want this to apply to all code because we can then get UB on (x86_64) machines that do not have these features. I thus had to create more static_libraries with separate compiler flags. I hope this is correct, but I am not sure how idiomatic or nice my approach is here at all.

One would typically do things a bit differently in a Rust project.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AVX‑512 streaming write path for faster bulk memory writes on supported x86_64 systems
  * Runtime detection with a new command-line option to disable AVX‑512 and enforced memory alignment when active

* **Chores**
  * Centralized common constants into a shared header
  * Build system updated for architecture-specific compilation and link-time object optimization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->