### PR TITLE
Fix UB in signal handler

### DIFF
--- a/memtouch.cpp
+++ b/memtouch.cpp
@@ -1,6 +1,7 @@
 #include <argparse.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <fstream>
@@ -20,6 +21,8 @@
 static constexpr uint64_t PAGE_SIZE(4096);
 static constexpr int      PATTERN(0xff);
 static constexpr int      DEFAULT_STAT_IVAL(1000);
+
+static std::atomic<bool> global_terminate{false};
 
 using namespace std;
 
@@ -110,17 +113,17 @@ class WorkerThread {
 
         // Warmup, write every page
         for (uint64_t page{0}; page < num_pages; ++page) {
-            if (terminate) {
+            if (global_terminate.load(std::memory_order_relaxed)) {
                 break;
             }
             write_page(page);
         }
 
         if (run_once) {
-            kill();
+            return;
         }
 
-        while (not terminate) {
+        while (not global_terminate.load(std::memory_order_relaxed)) {
             run_loop(num_pages);
         }
     }
@@ -230,8 +233,6 @@ class WorkerThread {
         return mem_base != MAP_FAILED;
     }
 
-    void kill() { terminate = true; }
-
     float write_rate() const { return stats.write_rate.load(); }
 
     float read_rate() const { return stats.read_rate.load(); }
@@ -242,8 +243,6 @@ class WorkerThread {
     unsigned mem_size_mib;
     unsigned rw_ratio;
     uint64_t page_log_ival;
-
-    bool terminate{false};
 
     void* mem_base{nullptr};
 
@@ -263,7 +262,7 @@ class StatisticsThread {
     }
 
     void run() {
-        while (not terminate) {
+        while (not global_terminate.load(std::memory_order_relaxed)) {
             float read_rate{0};
             float write_rate{0};
 
@@ -282,8 +281,6 @@ class StatisticsThread {
             usleep(logging_ival_ms * 1000);
         }
     }
-
-    void kill() { terminate = true; }
 
     void set_interval(unsigned ival_ms) { logging_ival_ms = ival_ms; }
 
@@ -316,7 +313,6 @@ class StatisticsThread {
    private:
     vector<WorkerThread>& workers;
 
-    bool     terminate{false};
     unsigned logging_ival_ms{DEFAULT_STAT_IVAL};
 
     ofstream log_file{};
@@ -329,11 +325,11 @@ StatisticsThread           stat_thread(worker_storage);
 
 void sigint_handler([[maybe_unused]] int s) {
     printf("Terminating...\n");
-    for (auto& worker : worker_storage) {
-        worker.kill();
-    }
 
-    stat_thread.kill();
+    static_assert(std::atomic<bool>::is_always_lock_free,
+                  "Unable to ensure async-signal-handler safety: std::atomic<bool> should always "
+                  "be lock free, but the assertion failed.");
+    global_terminate.store(true, std::memory_order_relaxed);
 }
 
 void setup_signals() {

--- a/memtouch.cpp
+++ b/memtouch.cpp
@@ -169,9 +169,15 @@ class WorkerThread {
     }
 
     void cleanup_memory() {
+        if (mem_base == nullptr || mem_base == MAP_FAILED) {
+            return;
+        }
+
         if (munmap(mem_base, uint64_t(mem_size_mib) * 1024 * 1024) != 0) {
             printf("Unable to unmap memory\n");
+            return;
         }
+        mem_base = nullptr;
     }
 
     bool allocate_memory() {

--- a/memtouch.cpp
+++ b/memtouch.cpp
@@ -24,11 +24,19 @@ static constexpr int      DEFAULT_STAT_IVAL(1000);
 using namespace std;
 
 struct Statistics {
-    Statistics() = default;
+    Statistics()                             = default;
+    Statistics(const Statistics&)            = delete;
+    Statistics& operator=(const Statistics&) = delete;
 
     Statistics(Statistics&& o) noexcept {
         write_rate.store(o.write_rate.load());
         read_rate.store(o.read_rate.load());
+    }
+
+    Statistics& operator=(Statistics&& o) noexcept {
+        write_rate.store(o.write_rate.load());
+        read_rate.store(o.read_rate.load());
+        return *this;
     }
 
     std::atomic<float> read_rate{0};
@@ -48,6 +56,43 @@ class WorkerThread {
           rw_ratio(rw_ratio_),
           page_log_ival(page_log_ival_),
           stats() {}
+
+    ~WorkerThread() { cleanup_memory(); }
+
+    WorkerThread(const WorkerThread&)            = delete;
+    WorkerThread& operator=(const WorkerThread&) = delete;
+
+    WorkerThread(WorkerThread&& o) noexcept
+        : id(o.id),
+          run_once(o.run_once),
+          mem_size_mib(o.mem_size_mib),
+          rw_ratio(o.rw_ratio),
+          page_log_ival(o.page_log_ival),
+          mem_base(o.mem_base),
+          read_buffer(),
+          stats(std::move(o.stats)) {
+        o.mem_base = nullptr;
+    }
+
+    WorkerThread& operator=(WorkerThread&& o) noexcept {
+        if (this == &o) {
+            return *this;
+        }
+
+        cleanup_memory();
+
+        id            = o.id;
+        run_once      = o.run_once;
+        mem_size_mib  = o.mem_size_mib;
+        rw_ratio      = o.rw_ratio;
+        page_log_ival = o.page_log_ival;
+        mem_base      = o.mem_base;
+        stats         = std::move(o.stats);
+
+        o.mem_base = nullptr;
+
+        return *this;
+    }
 
     bool pre_run() {
         if (not allocate_memory()) {
@@ -78,8 +123,6 @@ class WorkerThread {
         while (not terminate) {
             run_loop(num_pages);
         }
-
-        cleanup_memory();
     }
 
     int64_t measure_time_ns(std::function<void()> func) {


### PR DESCRIPTION
The way the signal handler is currently implemented we end up writing to bool's read by other threads without the use of atomics or synchronization. This is undefined behavior: It is subject to data races and/or some compilers (either existing or to appear in the future) may end up optimizing the reads out entirely.

We fix this by using a single static `std::atomic<bool>` that the worker and statistics threads read from and the signal handler writes to.

The less invasive solution would be to replace each individual thread's `terminate` bool with an `std::atomic<bool>`, but I could not get the constructors to accept that. Moreover the compiler messages were rather arcane and hard to understand for someone who just started writing C++. There is probably something fancy going on with copy constructors and/or constexpr or what have you. 

Overall I personally prefer this simpler solution, while admitting that it is less flexible if individual thread termination should be desired in the future.  I am going with the YAGNI principle here.

This was first brought up in [this previous discussion](https://github.com/cobaltcore-dev/memtouch/pull/35#discussion_r3162238688).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified process-wide shutdown so all worker and background threads stop reliably when interrupted.
  * Signal-triggered shutdown made safer and more robust.
  * Threads and related objects made non-copyable/movable to prevent misuse during teardown.
  * Resource cleanup hardened to avoid double-free or null/dangling memory operations during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->